### PR TITLE
Update for purescript 0.8.5, and use List instead of Array internally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,167 +1,300 @@
-# Module Documentation
-
 ## Module Data.Typeable
 
-### Types
+#### `TypeRep`
+
+``` purescript
+data TypeRep
+  = TypeRep TyCon (List TypeRep)
+```
+
+##### Instances
+``` purescript
+Eq TypeRep
+Ord TypeRep
+Show TypeRep
+```
+
+#### `TyCon`
+
+``` purescript
+data TyCon
+  = TyCon { tyConModule :: String, tyConName :: String }
+```
+
+##### Instances
+``` purescript
+Eq TyCon
+Ord TyCon
+Show TyCon
+```
+
+#### `Typeable`
+
+``` purescript
+class Typeable a where
+  typeOf :: a -> TypeRep
+```
+
+##### Instances
+``` purescript
+(Typeable1 t, Typeable a) => Typeable (t a)
+Typeable Boolean
+Typeable Number
+Typeable String
+Typeable Unit
+Typeable Ordering
+```
+
+#### `Typeable1`
+
+``` purescript
+class Typeable1 t where
+  typeOf1 :: forall a. t a -> TypeRep
+```
+
+##### Instances
+``` purescript
+(Typeable2 t, Typeable a) => Typeable1 (t a)
+Typeable1 Array
+Typeable1 Fn0
+```
+
+#### `Typeable2`
+
+``` purescript
+class Typeable2 t where
+  typeOf2 :: forall a b. t a b -> TypeRep
+```
+
+##### Instances
+``` purescript
+(Typeable3 t, Typeable a) => Typeable2 (t a)
+Typeable2 Function
+Typeable2 Fn1
+```
+
+#### `Typeable3`
+
+``` purescript
+class Typeable3 t where
+  typeOf3 :: forall a b c. t a b c -> TypeRep
+```
+
+##### Instances
+``` purescript
+(Typeable4 t, Typeable a) => Typeable3 (t a)
+Typeable3 Fn2
+```
+
+#### `Typeable4`
+
+``` purescript
+class Typeable4 t where
+  typeOf4 :: forall a b c d. t a b c d -> TypeRep
+```
+
+##### Instances
+``` purescript
+(Typeable5 t, Typeable a) => Typeable4 (t a)
+Typeable4 Fn3
+```
+
+#### `Typeable5`
+
+``` purescript
+class Typeable5 t where
+  typeOf5 :: forall a b c d e. t a b c d e -> TypeRep
+```
+
+##### Instances
+``` purescript
+(Typeable6 t, Typeable a) => Typeable5 (t a)
+Typeable5 Fn4
+```
 
-    data TyCon where
-      TyCon :: { tyConName :: String, tyConModule :: String } -> TyCon
+#### `Typeable6`
 
-    data TypeRep where
-      TypeRep :: TyCon -> [TypeRep] -> TypeRep
+``` purescript
+class Typeable6 t where
+  typeOf6 :: forall a b c d e f. t a b c d e f -> TypeRep
+```
 
+##### Instances
+``` purescript
+(Typeable7 t, Typeable a) => Typeable6 (t a)
+Typeable6 Fn5
+```
 
-### Type Classes
+#### `Typeable7`
 
-    class Typeable a where
-      typeOf :: a -> TypeRep
+``` purescript
+class Typeable7 t where
+  typeOf7 :: forall a b c d e f g. t a b c d e f g -> TypeRep
+```
 
-    class Typeable1 t where
-      typeOf1 :: forall a. t a -> TypeRep
+##### Instances
+``` purescript
+(Typeable8 t, Typeable a) => Typeable7 (t a)
+Typeable7 Fn6
+```
 
-    class Typeable10 t where
-      typeOf10 :: forall a b c d e f g h i j. t a b c d e f g h i j -> TypeRep
+#### `Typeable8`
 
-    class Typeable11 t where
-      typeOf11 :: forall a b c d e f g h i j k. t a b c d e f g h i j k -> TypeRep
+``` purescript
+class Typeable8 t where
+  typeOf8 :: forall a b c d e f g h. t a b c d e f g h -> TypeRep
+```
 
-    class Typeable2 t where
-      typeOf2 :: forall a b. t a b -> TypeRep
+##### Instances
+``` purescript
+(Typeable9 t, Typeable a) => Typeable8 (t a)
+Typeable8 Fn7
+```
 
-    class Typeable3 t where
-      typeOf3 :: forall a b c. t a b c -> TypeRep
+#### `Typeable9`
 
-    class Typeable4 t where
-      typeOf4 :: forall a b c d. t a b c d -> TypeRep
+``` purescript
+class Typeable9 t where
+  typeOf9 :: forall a b c d e f g h i. t a b c d e f g h i -> TypeRep
+```
 
-    class Typeable5 t where
-      typeOf5 :: forall a b c d e. t a b c d e -> TypeRep
+##### Instances
+``` purescript
+(Typeable10 t, Typeable a) => Typeable9 (t a)
+Typeable9 Fn8
+```
 
-    class Typeable6 t where
-      typeOf6 :: forall a b c d e f. t a b c d e f -> TypeRep
+#### `Typeable10`
 
-    class Typeable7 t where
-      typeOf7 :: forall a b c d e f g. t a b c d e f g -> TypeRep
+``` purescript
+class Typeable10 t where
+  typeOf10 :: forall a b c d e f g h i j. t a b c d e f g h i j -> TypeRep
+```
 
-    class Typeable8 t where
-      typeOf8 :: forall a b c d e f g h. t a b c d e f g h -> TypeRep
+##### Instances
+``` purescript
+(Typeable11 t, Typeable a) => Typeable10 (t a)
+Typeable10 Fn9
+```
 
-    class Typeable9 t where
-      typeOf9 :: forall a b c d e f g h i. t a b c d e f g h i -> TypeRep
+#### `Typeable11`
 
+``` purescript
+class Typeable11 t where
+  typeOf11 :: forall a b c d e f g h i j k. t a b c d e f g h i j k -> TypeRep
+```
 
-### Type Class Instances
+##### Instances
+``` purescript
+Typeable11 Fn10
+```
 
-    instance eqTyCon :: Eq TyCon
+#### `typeRepTyCon`
 
-    instance eqTypeRep :: Eq TypeRep
+``` purescript
+typeRepTyCon :: TypeRep -> TyCon
+```
 
-    instance ordTyCon :: Ord TyCon
+#### `typeRepReps`
 
-    instance ordTypeRep :: Ord TypeRep
+``` purescript
+typeRepReps :: TypeRep -> List TypeRep
+```
 
-    instance showTyCon :: Show TyCon
+#### `mkTyRep`
 
-    instance showTypeRep :: Show TypeRep
+``` purescript
+mkTyRep :: String -> String -> TypeRep
+```
 
-    instance typeable10Fn9 :: Typeable10 Fn9
+#### `mkTyConApp`
 
-    instance typeable11Fn10 :: Typeable11 Fn10
+``` purescript
+mkTyConApp :: TyCon -> List TypeRep -> TypeRep
+```
 
-    instance typeable1Array :: Typeable1 Prim.Array
+#### `mkAppTy`
 
-    instance typeable1Fn0 :: Typeable1 Fn0
+``` purescript
+mkAppTy :: TypeRep -> TypeRep -> TypeRep
+```
 
-    instance typeable1FromTypeable2 :: (Typeable2 t, Typeable a) => Typeable1 (t a)
+#### `typeOfDefault`
 
-    instance typeable2Arr :: Typeable2 Prim.Function
+``` purescript
+typeOfDefault :: forall t a. (Typeable1 t, Typeable a) => t a -> TypeRep
+```
 
-    instance typeable2Fn1 :: Typeable2 Fn1
+#### `typeOf1Default`
 
-    instance typeable2FromTypeable3 :: (Typeable3 t, Typeable a) => Typeable2 (t a)
+``` purescript
+typeOf1Default :: forall t a b. (Typeable2 t, Typeable a) => t a b -> TypeRep
+```
 
-    instance typeable3Fn2 :: Typeable3 Fn2
+#### `typeOf2Default`
 
-    instance typeable3FromTypeable4 :: (Typeable4 t, Typeable a) => Typeable3 (t a)
+``` purescript
+typeOf2Default :: forall t a b c. (Typeable3 t, Typeable a) => t a b c -> TypeRep
+```
 
-    instance typeable4Fn3 :: Typeable4 Fn3
+#### `typeOf3Default`
 
-    instance typeable4FromTypeable5 :: (Typeable5 t, Typeable a) => Typeable4 (t a)
+``` purescript
+typeOf3Default :: forall t a b c d. (Typeable4 t, Typeable a) => t a b c d -> TypeRep
+```
 
-    instance typeable5Fn4 :: Typeable5 Fn4
+#### `typeOf4Default`
 
-    instance typeable5FromTypeable6 :: (Typeable6 t, Typeable a) => Typeable5 (t a)
+``` purescript
+typeOf4Default :: forall t a b c d e. (Typeable5 t, Typeable a) => t a b c d e -> TypeRep
+```
 
-    instance typeable6Fn5 :: Typeable6 Fn5
+#### `typeOf5Default`
 
-    instance typeable6FromTypeable7 :: (Typeable7 t, Typeable a) => Typeable6 (t a)
+``` purescript
+typeOf5Default :: forall t a b c d e f. (Typeable6 t, Typeable a) => t a b c d e f -> TypeRep
+```
 
-    instance typeable7Fn6 :: Typeable7 Fn6
+#### `typeOf6Default`
 
-    instance typeable7FromTypeable8 :: (Typeable8 t, Typeable a) => Typeable7 (t a)
+``` purescript
+typeOf6Default :: forall t a b c d e f g. (Typeable7 t, Typeable a) => t a b c d e f g -> TypeRep
+```
 
-    instance typeable8Fn7 :: Typeable8 Fn7
+#### `typeOf7Default`
 
-    instance typeable8FromTypeable9 :: (Typeable9 t, Typeable a) => Typeable8 (t a)
+``` purescript
+typeOf7Default :: forall t a b c d e f g h. (Typeable8 t, Typeable a) => t a b c d e f g h -> TypeRep
+```
 
-    instance typeable9Fn8 :: Typeable9 Fn8
+#### `typeOf8Default`
 
-    instance typeable9FromTypeable10 :: (Typeable10 t, Typeable a) => Typeable9 (t a)
+``` purescript
+typeOf8Default :: forall t a b c d e f g h i. (Typeable9 t, Typeable a) => t a b c d e f g h i -> TypeRep
+```
 
-    instance typeable9FromTypeable11 :: (Typeable11 t, Typeable a) => Typeable10 (t a)
+#### `typeOf9Default`
 
-    instance typeableBoolean :: Typeable Boolean
+``` purescript
+typeOf9Default :: forall t a b c d e f g h i j. (Typeable10 t, Typeable a) => t a b c d e f g h i j -> TypeRep
+```
 
-    instance typeableFromTypeable1 :: (Typeable1 t, Typeable a) => Typeable (t a)
+#### `typeOf10Default`
 
-    instance typeableNumber :: Typeable Number
+``` purescript
+typeOf10Default :: forall t a b c d e f g h i j k. (Typeable11 t, Typeable a) => t a b c d e f g h i j k -> TypeRep
+```
 
-    instance typeableOrdering :: Typeable Ordering
+#### `arrayTc`
 
-    instance typeableString :: Typeable String
+``` purescript
+arrayTc :: TyCon
+```
 
-    instance typeableUnit :: Typeable Unit
+#### `funTc`
 
-
-### Values
-
-    arrTc :: TyCon
-
-    arrayTc :: TyCon
-
-    mkAppTy :: TypeRep -> TypeRep -> TypeRep
-
-    mkTyConApp :: TyCon -> [TypeRep] -> TypeRep
-
-    mkTyRep :: String -> String -> TypeRep
-
-    typeOf10Default :: forall t a b c d e f g h i j k. (Typeable11 t, Typeable a) => t a b c d e f g h i j k -> TypeRep
-
-    typeOf1Default :: forall t a b. (Typeable2 t, Typeable a) => t a b -> TypeRep
-
-    typeOf2Default :: forall t a b c. (Typeable3 t, Typeable a) => t a b c -> TypeRep
-
-    typeOf3Default :: forall t a b c d. (Typeable4 t, Typeable a) => t a b c d -> TypeRep
-
-    typeOf4Default :: forall t a b c d e. (Typeable5 t, Typeable a) => t a b c d e -> TypeRep
-
-    typeOf5Default :: forall t a b c d e f. (Typeable6 t, Typeable a) => t a b c d e f -> TypeRep
-
-    typeOf6Default :: forall t a b c d e f g. (Typeable7 t, Typeable a) => t a b c d e f g -> TypeRep
-
-    typeOf7Default :: forall t a b c d e f g h. (Typeable8 t, Typeable a) => t a b c d e f g h -> TypeRep
-
-    typeOf8Default :: forall t a b c d e f g h i. (Typeable9 t, Typeable a) => t a b c d e f g h i -> TypeRep
-
-    typeOf9Default :: forall t a b c d e f g h i j. (Typeable10 t, Typeable a) => t a b c d e f g h i j -> TypeRep
-
-    typeOfDefault :: forall t a. (Typeable1 t, Typeable a) => t a -> TypeRep
-
-    typeRepReps :: TypeRep -> [TypeRep]
-
-    typeRepTyCon :: TypeRep -> TyCon
-
-    unsafeCoerce :: forall a b. a -> b
-
+``` purescript
+funTc :: TyCon
+```
 
 

--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,9 @@
     "tests"
   ],
   "dependencies": {
-    "purescript-arrays": "~0.1.8"
+    "purescript-arrays": "~0.4.5",
+    "purescript-functions": "~0.1.0",
+    "purescript-unsafe-coerce": "~0.1.1",
+    "purescript-lists": "~0.7.10"
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,10 +6,9 @@ var gulp       = require('gulp')
 
 var paths = {
     src: 'src/**/*.purs',
-    bowerSrc: [
-      'bower_components/purescript-*/src/**/*.purs',
-      'bower_components/purescript-*/src/**/*.purs.hs'
-    ],
+    foreigns: 'src/**/*.js',
+    bowerSrc: 'bower_components/purescript-*/src/**/*.purs',
+    bowerForeigns: 'bower_components/purescript-*/src/**/*.js',
     dest: '',
     docsDest: 'README.md'
 };
@@ -30,17 +29,24 @@ var compile = function(compiler) {
 };
 
 gulp.task('make', function() {
-    return compile(purescript.pscMake);
+    return purescript.psc({
+        src: [paths.src, paths.bowerSrc],
+        ffi: [paths.foreigns, paths.bowerForeigns]
+    });
 });
 
 gulp.task('browser', function() {
     return compile(purescript.psc);
 });
 
-gulp.task('docs', function() {
-    return gulp.src(paths.src)
-      .pipe(purescript.docgen())
-      .pipe(gulp.dest(paths.docsDest));
+gulp.task("docs", ["make"], function () {
+    return purescript.pscDocs({
+        src: [paths.src, paths.bowerSrc],
+        format: "markdown",
+        docgen: {
+            "Data.Typeable": paths.docsDest
+        }
+    });
 });
 
 gulp.task('watch-browser', function() {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "PureScript implementation of Typeable.",
   "license": "MIT",
   "devDependencies": {
-    "gulp": "^3.8.7",
-    "gulp-purescript": "0.0.9"
+    "gulp": "^3.9.1",
+    "gulp-purescript": "0.8.0"
   }
 }


### PR DESCRIPTION
Greetings!

I am interested in `Data.Typeable` in the context of this issue:

https://github.com/rgrempel/purescript-elm/issues/10

I'm using a (possibly viable) trick at the moment (described there), but a more "correct" solution would involve `Data.Typeable`.

As a first step, I've updated the existing code to compile with Purescript 0.8.5.

In doing that, the compiler complained that the `show` instance was partial, which was true, so I've completed that. Given certain changes to how pattern-matching on arrays works, it was easier to do this if we switched to using `List` internally instead of `Array`, so I've done that as well.

I also fixed some things in the Gulpfile to correspond to the current usage of purescript-gulp. (I didn't fix it all).

So, that seems like a possibly useful set of changes.
