### PR TITLE
Update dependencies to work with latest purescript.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,10 +24,10 @@
     "tests"
   ],
   "dependencies": {
-    "purescript-functions": "^1.0.0",
-    "purescript-unsafe-coerce": "^1.0.0",
-    "purescript-lists": "^1.0.0",
-    "purescript-foldable-traversable": "^1.0.0",
-    "purescript-prelude": "^1.0.0"
+    "purescript-unsafe-coerce": "^2.0.0",
+    "purescript-lists": "^3.3.0",
+    "purescript-foldable-traversable": "^2.1.0",
+    "purescript-prelude": "^2.1.0",
+    "purescript-functions": "^2.0.0"
   }
 }

--- a/src/Data/Typeable.purs
+++ b/src/Data/Typeable.purs
@@ -5,7 +5,6 @@ module Data.Typeable where
 
   import Data.Function.Uncurried
     ( Fn0
-    , Fn1
     , Fn2
     , Fn3
     , Fn4
@@ -171,7 +170,7 @@ module Data.Typeable where
   instance typeable1Fn0 :: Typeable1 Fn0 where
     typeOf1 _ = mkTyRep "Data.Function" "Fn0"
 
-  instance typeable2Fn1 :: Typeable2 Fn1 where
+  instance typeable2Fn1 :: Typeable2 (->) where
     typeOf2 _ = mkTyRep "Data.Function" "Fn1"
 
   instance typeable3Fn2 :: Typeable3 Fn2 where


### PR DESCRIPTION
I also changed the definition for Fn1 to be (->) since it
is defined as a type alias in the purescript-functions package
and we cannot define instances for type aliases anymore.